### PR TITLE
fix a issue of RuntimeError

### DIFF
--- a/improved_diffusion/dist_util.py
+++ b/improved_diffusion/dist_util.py
@@ -69,7 +69,7 @@ def sync_params(params):
     """
     for p in params:
         with th.no_grad():
-            dist.broadcast(p, 0)
+            dist.broadcast(p.detach(), 0)
 
 
 def _find_free_port():


### PR DESCRIPTION
fix the bug of RuntimeError: a leaf Variable that requires grad is being used in an in-place operation, detail can be seen at this [issue](https://github.com/openai/improved-diffusion/issues/23)