### PR TITLE
mpi4py - package installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Clone this repository and navigate to it in your terminal. Then run:
 
 ```
 pip install -e .
+conda install mpi4py
 ```
 
 This should install the `improved_diffusion` python package that the scripts depend on.


### PR DESCRIPTION
Conda users can install mpi4py seamlessly using Conda. To run the scripts, the code requires that package, which appears to be missing; pip installation terminates with wheel error.
