### PR TITLE
BUG FIX: fp16 "TypeError: unflatten_dense_tensors(): argument 'tensors' (position 2) must be tuple of Tensors, not generator"

### DIFF
--- a/improved_diffusion/fp16_util.py
+++ b/improved_diffusion/fp16_util.py
@@ -65,7 +65,7 @@ def unflatten_master_params(model_params, master_params):
     """
     Unflatten the master parameters to look like model_params.
     """
-    return _unflatten_dense_tensors(master_params[0].detach(), model_params)
+    return _unflatten_dense_tensors(master_params[0].detach(), tuple(tensor for tensor in model_params))
 
 
 def zero_grad(model_params):


### PR DESCRIPTION
If you try to use the fp16 flag to train your model, you will likely see the above message. This pull request fixes that issue. I believe this repository is not being updated / maintained, so this fix is here for anyone who runs into this issue.

The fix changes only a single line of code so it's quite easy to implement yourself.